### PR TITLE
Fix code sample in `Developing in Go`

### DIFF
--- a/site/book/05-developing-functions/02-developing-in-Go.md
+++ b/site/book/05-developing-functions/02-developing-in-Go.md
@@ -78,7 +78,7 @@ adds the annotation. After the iteration, it adds some user message to the `Reso
 ```go
 func Run(rl *fn.ResourceList) (bool, error) {
     for _, kubeObject := range rl.Items {
-        if kubeObject.IsGVK("v1", "Deployment") {
+        if kubeObject.IsGVK("apps/v1", "Deployment") {
             kubeObject.SetAnnotation("config.kubernetes.io/managed-by", "kpt")
         }
     }


### PR DESCRIPTION
Fix code sample in [Developing in Go](https://kpt.dev/book/05-developing-functions/02-developing-in-Go?id=write-the-krm-function-logic)

api version for deployment is `apps/v1` instead of `v1`. Previous code doesn't match and doesn't add the annotation
